### PR TITLE
setup.sh to support python3.12 in version check

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -25,7 +25,7 @@ function check_installed_python() {
         exit 2
     fi
 
-    for v in 11 10 9
+    for v in 12 11 10 9
     do
         PYTHON="python3.${v}"
         which $PYTHON


### PR DESCRIPTION
added 12 to the minor supported versions check

## Summary

setup.sh was failing python version check, 3.9 minimum and the check has 9,10,11 as minor but 3.12.3 installed.

## Quick changelog

add 12 to for version loop.
